### PR TITLE
 `TransferMessage`: add an optional `aurora_sender` field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub const STANDARD: &str = "nep297";
 pub const VERSION: &str = "1.0.0";
 pub const EVENT_JSON_STR: &str = "EVENT_JSON:";
 
-#[derive(BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq)]
+#[derive(BorshDeserialize, BorshSerialize, Debug, Clone, Copy, PartialEq)]
 pub struct EthAddress(pub [u8; 20]);
 
 impl<'de> Deserialize<'de> for EthAddress {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub const VERSION: &str = "1.0.0";
 pub const EVENT_JSON_STR: &str = "EVENT_JSON:";
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq)]
-pub struct EthAddress([u8; 20]);
+pub struct EthAddress(pub [u8; 20]);
 
 impl<'de> Deserialize<'de> for EthAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, <D as serde::Deserializer<'de>>::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub struct TransferMessage {
     #[serde(with = "hex::serde")]
     pub recipient: EthAddress,
     pub valid_till_block_height: Option<u64>,
+    pub aurora_sender: Option<EthAddress>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Add an optional  `aurora_sender` field to `TransferMessage` to contain the sender data if the transaction originated from Aurora. This is required, for example,  for proper user `unlock()` of Fast Bridge transfer directly on Aurora.